### PR TITLE
Replace use of resolve with get and helper functions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chai": "^4.3.4",
     "mocha": "^9.1.3",
     "require-dir": "^1.2.0",
-    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations#add-endpoint-class"
+    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations"
   },
   "devDependencies": {
     "eslint": "^7.23.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chai": "^4.3.4",
     "mocha": "^9.1.3",
     "require-dir": "^1.2.0",
-    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations"
+    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations#add-endpoint-class"
   },
   "devDependencies": {
     "eslint": "^7.23.0",


### PR DESCRIPTION
https://github.com/w3c-ccg/vc-api-test-suite-implementations/pull/32

replaces `didResolver.resolve` with `didResolver.get`